### PR TITLE
SFB-216: Remove static paths from dispatcher

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -24,10 +24,6 @@ defmodule Dispatcher do
     forward conn, path, "http://frontend/assets/"
   end
 
-  match "/forms/*path", %{ layer: :static } do
-    forward conn, path, "http://frontend/forms/"
-  end
-
   get "/@appuniversum/*path", %{ layer: :static } do
     forward conn, path, "http://frontend/@appuniversum/"
   end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -17,25 +17,6 @@ defmodule Dispatcher do
     |> send_resp( 200, "{ \"message\": \"ok\" }" )
   end
 
-  ###############
-  # STATIC
-  ###############
-  match "/assets/*path", %{ layer: :static } do
-    forward conn, path, "http://frontend/assets/"
-  end
-
-  get "/@appuniversum/*path", %{ layer: :static } do
-    forward conn, path, "http://frontend/@appuniversum/"
-  end
-
-  match "/index.html", %{ layer: :static } do
-    forward conn, [], "http://frontend/index.html"
-  end
-
-  match "/favicon.ico", %{ layer: :static } do
-    send_resp( conn, 404, "" )
-  end
-
   #################
   # FRONTEND PAGES
   #################


### PR DESCRIPTION
## Issue
 [SFB-216](https://binnenland.atlassian.net/browse/SFB-216)

## Description

When creating a new route in our frontend `/forms` all specific uri's are not available when going directly to them. Backend returns a 404. We found out that there is a static path defined named `/forms` in the dispatcher. This path is never used just as all the static routes.

All static paths are removed.

## Test

1. See if the frontend application is using any of the removed paths in the dispatcher file.
