### PR TITLE
SFB 219: remove user tests data with migration

### DIFF
--- a/config/migrations/20240314164537-delete-user-tests.sparql
+++ b/config/migrations/20240314164537-delete-user-tests.sparql
@@ -1,0 +1,10 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/application> {
+    ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://mu.semte.ch/vocabularies/ext/UserTest> .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/application> {
+    ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://mu.semte.ch/vocabularies/ext/UserTest> .
+  }
+}


### PR DESCRIPTION
Don't need user tests anymore, remove it from the backend